### PR TITLE
Speed and stability improvements

### DIFF
--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -238,6 +238,12 @@ class Uploader:
         log.info(r)
         return r
 
+    def file_do(self, f):
+        log.info('Executing '+f)
+        r = self.exchange('dofile("'+f+'")')
+        log.info(r)
+        return r
+
     def file_format(self):
         log.info('Formating...')
         self._port.write('file.format()' + '\r\n')
@@ -364,7 +370,8 @@ if __name__ == '__main__':
         'file',
         help = 'File functions')
 
-    file_parser.add_argument('cmd', choices=('list', 'format'))
+    file_parser.add_argument('cmd', choices=('list', 'do', 'format'))
+    file_parser.add_argument('filename', nargs='*', help = 'Lua file to run.')
 
     node_parse = subparsers.add_parser(
         'node', 
@@ -419,6 +426,9 @@ if __name__ == '__main__':
     elif args.operation == 'file':
         if args.cmd == 'list':
             uploader.file_list()
+        if args.cmd == 'do':
+            for f in args.filename:
+                uploader.file_do(f)
         elif args.cmd == 'format':
             uploader.file_format()
     

--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -57,7 +57,7 @@ CHUNK_REPLY = '\v'
 class Uploader:
     BAUD = 9600
     PORT = '/dev/ttyUSB0'
-    TIMEOUT = 1
+    TIMEOUT = 3
 
     def expect(self, exp='> ', timeout=TIMEOUT):
         t = self._port.timeout
@@ -96,7 +96,9 @@ class Uploader:
         self._port.setRTS(False)
         self._port.setDTR(False)
 
-        # Get in sync with LUA
+        # Get in sync with LUA (this assumes that NodeMCU gets reset by the previous two lines)
+        self.expect('NodeMCU ')
+        self.expect()
         self.exchange('')
 
         if baud != Uploader.BAUD:

--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -81,6 +81,7 @@ class Uploader:
     def write(self, output):
         log.debug('write: '+output)
         self._port.write(output + '\r\n')
+        self._port.flush()
 
     def exchange(self, output):
         self.write(output)

--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -75,9 +75,11 @@ class Uploader:
             data += self._port.read()
 
         self._port.timeout = t
+        log.debug('expect return: '+data)
         return data
 
     def write(self, output):
+        log.debug('write: '+output)
         self._port.write(output + '\r\n')
 
     def exchange(self, output):

--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -367,9 +367,10 @@ if __name__ == '__main__':
     formatter = logging.Formatter('%(message)s')
     logging.basicConfig(level=logging.INFO, format='%(message)s')
 
-    uploader = Uploader(args.port, args.baud)
     if args.verbose:
         log.setLevel(logging.DEBUG)
+
+    uploader = Uploader(args.port, args.baud)
 
     if args.operation == 'upload' or args.operation == 'download':
         sources = args.filename

--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -109,8 +109,15 @@ class Uploader:
 
         if baud != Uploader.BAUD:
             log.info('Changing communication to %s baud', baud)
-            self.exchange('uart.setup(0,%s,8,0,1,1)' % baud)
-            self._port.baudrate = baud
+            self.writeln('uart.setup(0,%s,8,0,1,1)' % baud)
+
+            # Wait for the string to be sent before switching baud
+            time.sleep(0.1)
+            self._port.setBaudrate(baud)
+
+            # Get in sync again
+            self.exchange('')
+            self.exchange('')
 
         self.line_number = 0
 

--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -74,8 +74,7 @@ class Uploader:
             log.info('Changing communication to %s baud', baud)
             self._port.write('uart.setup(0,%s,8,0,1,1)\r\n' % baud)
             log.info(self.dump())
-            self._port.close()
-            self._port = serial.Serial(port, baud, timeout=Uploader.TIMEOUT)
+            self._port.baudrate = 115200
 
         self.line_number = 0
 

--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -57,7 +57,7 @@ CHUNK_REPLY = '\v'
 class Uploader:
     BAUD = 9600
     PORT = '/dev/ttyUSB0'
-    TIMEOUT = 3
+    TIMEOUT = 5
 
     def expect(self, exp='> ', timeout=TIMEOUT):
         t = self._port.timeout

--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -77,8 +77,11 @@ class Uploader:
         self._port.timeout = t
         return data
 
-    def exchange(self, output):
+    def write(self, output):
         self._port.write(output + '\r\n')
+
+    def exchange(self, output):
+        self.write(output)
         return self.expect()
 
     def __init__(self, port = 0, baud = BAUD):
@@ -95,14 +98,13 @@ class Uploader:
 
         if baud != Uploader.BAUD:
             log.info('Changing communication to %s baud', baud)
-            self._port.write('uart.setup(0,%s,8,0,1,1)\r\n' % baud)
-            log.info(self.dump())
+            self.exchange('uart.setup(0,%s,8,0,1,1)' % baud)
             self._port.baudrate = baud
 
         self.line_number = 0
 
     def close(self):
-        self._port.write('uart.setup(0,%s,8,0,1,1)\r\n' % Uploader.BAUD)
+        self.write('uart.setup(0,%s,8,0,1,1)' % Uploader.BAUD)
         self._port.close()
 
     def dump(self, timeout=TIMEOUT):


### PR DESCRIPTION
I have replaced the dump method by an exchange (write/expect) method that waits for an expected response. This way the timeout is merely used for exceptions. Under normal circumstances the timeout is never reached and the code goes as fast as the NodeMCU can respond. This gives serious speed improves for listing files, uploading files, etc.. We could now also extend the expect method to raise an exception on timeout and then abort or retry. Also baudrate switching is improved.