### PR TITLE
Changed synchronization with the lua interpreter.

### DIFF
--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -103,9 +103,9 @@ class Uploader:
         self._port.setDTR(False)
 
         # Get in sync with LUA (this assumes that NodeMCU gets reset by the previous two lines)
-        self.expect('NodeMCU ')
-        self.expect()
-        self.exchange('')
+        self.exchange(';'); # Get a defined state
+        self.writeln('print("%sync%");');
+        self.expect('%sync%\r\n> ');
 
         if baud != Uploader.BAUD:
             log.info('Changing communication to %s baud', baud)


### PR DESCRIPTION
Wait for "%sync%" output from a print call. With this,
nodemcu-uploader can be used without connecting the reset line to
DTR. Reset is optional.

What do you think? Any drawbacks i missed?
