### PR TITLE
Don't compile init.lua when uploading.

### DIFF
--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -457,7 +457,7 @@ if __name__ == '__main__':
                     if args.compile:
                         uploader.file_remove(os.path.splitext(d)[0]+'.lc')
                     uploader.write_file(f, d, args.verify)
-                    if args.compile:
+                    if args.compile and d != 'init.lua':
                         uploader.file_compile(d)
                         uploader.file_remove(d)
                         if args.dofile:


### PR DESCRIPTION
Prevent the file `init.lua` from being compiled when uploaded as part of
a set of files.

When uploading a whole project at once with the `--compile`-option set,
compiling the `init.lua` essentially breaks the application, because
`init.lc` is not recognized as valid entry-point.