### PR TITLE
Added setup.py in order to allow installation by pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(name='nodemcu-uploader',
+      version='0.1.0-beta',
+      install_requires=[
+          'pyserial>=3.0'
+      ],
+      scripts = ['nodemcu-uploader.py'],
+      url='https://github.com/kmpm/nodemcu-uploader',
+      author='kmpm'
+)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(name='nodemcu-uploader',
       version='0.1.0-beta',
       install_requires=[
-          'pyserial>=3.0'
+          'pyserial==2.7'
       ],
       scripts = ['nodemcu-uploader.py'],
       url='https://github.com/kmpm/nodemcu-uploader',


### PR DESCRIPTION
Without the setup.py, the package cannot be installed with pip (nor used as a dependency for other projects)