### PR TITLE
Timeout option for the commands

### DIFF
--- a/nodemcu_uploader/main.py
+++ b/nodemcu_uploader/main.py
@@ -33,7 +33,7 @@ def destination_from_source(sources):
                 newsources.append(filename)
                 #always use forward slash at destination
                 destinations.append(filename.replace('\\', '/'))
-            
+
     return [newsources, destinations]
 
 
@@ -235,10 +235,10 @@ def main_func():
 
     # let uploader user the default (short) timeout for establishing connection
     uploader = Uploader(args.port, args.baud, start_baud=args.start_baud)
-    
+
     # and reset the timeout (if we have the uploader&timeout)
     if args.timeout:
-        uploader.TIMEOUT = args.timeout
+        uploader.set_timeout(args.timeout)
 
     if args.operation == 'upload':
         operation_upload(uploader, args.filename, args.verify, args.compile, args.dofile,
@@ -262,6 +262,3 @@ def main_func():
             uploader.node_restart()
     #no uploader related commands after this point
     uploader.close()
-
-
-

--- a/nodemcu_uploader/main.py
+++ b/nodemcu_uploader/main.py
@@ -133,6 +133,12 @@ def main_func():
         type=arg_auto_int,
         default=Uploader.START_BAUD)
 
+    parser.add_argument(
+        '--timeout', '-t',
+        help='Timeout for operations',
+        type=arg_auto_int,
+        default=Uploader.TIMEOUT)
+
     subparsers = parser.add_subparsers(
         dest='operation',
         help='Run nodemcu-uploader {command} -h for additional help')
@@ -227,7 +233,12 @@ def main_func():
         terminal(args.port)
         return
 
+    # let uploader user the default (short) timeout for establishing connection
     uploader = Uploader(args.port, args.baud, start_baud=args.start_baud)
+    
+    # and reset the timeout (if we have the uploader&timeout)
+    if args.timeout:
+        uploader.TIMEOUT = args.timeout
 
     if args.operation == 'upload':
         operation_upload(uploader, args.filename, args.verify, args.compile, args.dofile,

--- a/nodemcu_uploader/uploader.py
+++ b/nodemcu_uploader/uploader.py
@@ -89,8 +89,9 @@ class Uploader(object):
             self._port.flushOutput()
 
 
-    def expect(self, exp='> ', timeout=TIMEOUT):
+    def expect(self, exp='> ', timeout=None):
         """will wait for exp to be returned from nodemcu or timeout"""
+        timeout = timeout or self.TIMEOUT
         #do NOT set timeout on Windows
         if SYSTEM != 'Windows':
             timer = self._port.timeout
@@ -133,10 +134,10 @@ class Uploader(object):
         """write, with linefeed"""
         self.write(output + '\n')
 
-    def exchange(self, output, timeout=TIMEOUT):
+    def exchange(self, output, timeout=None):
         self.writeln(output)
         self._port.flush()
-        return self.expect(timeout=timeout)
+        return self.expect(timeout=timeout or self.TIMEOUT)
 
 
     def close(self):


### PR DESCRIPTION
'exec' operations can take longer than 5s to complete; the timeout options should solve the problem - the initial connection will be still established using the original timeouts and can be overriden