### PR TITLE
Python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ env3/
 
 # editors
 .vscode/
+.tox

--- a/nodemcu_uploader/main.py
+++ b/nodemcu_uploader/main.py
@@ -3,6 +3,7 @@
 
 """This module is the cli for the Uploader class"""
 
+from __future__ import print_function
 
 import argparse
 import logging
@@ -11,6 +12,7 @@ import glob
 from .uploader import Uploader
 from .term import terminal
 from serial import VERSION as serialversion
+
 
 log = logging.getLogger(__name__) # pylint: disable=C0103
 from .version import __version__
@@ -73,8 +75,8 @@ def operation_upload(uploader, sources, verify, do_compile, do_file, do_restart)
 def operation_download(uploader, sources):
     """The download operation"""
     sources, destinations = destination_from_source(sources, False)
-    print 'sources', sources
-    print 'destinations', destinations
+    print('sources', sources)
+    print('destinations', destinations)
     if len(destinations) == len(sources):
         if uploader.prepare():
             for filename, dst in zip(sources, destinations):

--- a/nodemcu_uploader/uploader.py
+++ b/nodemcu_uploader/uploader.py
@@ -3,7 +3,7 @@
 """Main functionality for nodemcu-uploader"""
 
 # Not sure about it, because UnicodeEncodeError throws anyway
-from __future__ import unicode_literals
+# from __future__ import unicode_literals
 
 
 import time

--- a/nodemcu_uploader/utils.py
+++ b/nodemcu_uploader/utils.py
@@ -5,9 +5,11 @@
 from platform import system
 from os import environ
 from wrapt import ObjectProxy
+from sys import version_info
 
 __all__ = ['default_port', 'system']
 
+PY2 = version_info.major == 2
 
 ENCODING = 'latin1'
 
@@ -26,7 +28,7 @@ def bytefy(x):
 
 
 def to_hex(x):
-    return hex(x) if type(x) == bytes else hex(ord(x))
+    return hex(ord(x))
 
 
 def hexify(byte_arr):
@@ -35,16 +37,18 @@ def hexify(byte_arr):
 
 def from_file(path):
     with open(path, 'rb') as f:
-        content = f.read().decode(ENCODING)
-    return content
+        content = f.read()
+    return content if PY2 else content.decode(ENCODING)
 
 
 class DecoderWrapper(ObjectProxy):
     def read(self, *args, **kwargs):
-        return self.__wrapped__.read(*args, **kwargs).decode(ENCODING)
+        res = self.__wrapped__.read(*args, **kwargs)
+        return res if PY2 else res.decode(ENCODING)
 
     def write(self, data):
-        return self.__wrapped__.write(data.encode(ENCODING))
+        data = data if PY2 else data.encode(ENCODING)
+        return self.__wrapped__.write(data)
 
 
 def wrap(x):

--- a/nodemcu_uploader/utils.py
+++ b/nodemcu_uploader/utils.py
@@ -4,8 +4,13 @@
 
 from platform import system
 from os import environ
+from wrapt import ObjectProxy
 
 __all__ = ['default_port', 'system']
+
+
+ENCODING = 'latin1'
+
 
 def default_port(sysname=system()):
     """This returns the default port used for different systems if SERIALPORT env variable is not set"""
@@ -15,3 +20,32 @@ def default_port(sysname=system()):
     }.get(sysname, '/dev/ttyUSB0')
     return environ.get('SERIALPORT', system_default)
 
+
+def bytefy(x):
+    return x if type(x) == bytes else x.encode(ENCODING)
+
+
+def to_hex(x):
+    return hex(x) if type(x) == bytes else hex(ord(x))
+
+
+def hexify(byte_arr):
+    return ':'.join((to_hex(x)[2:] for x in byte_arr))
+
+
+def from_file(path):
+    with open(path, 'rb') as f:
+        content = f.read().decode(ENCODING)
+    return content
+
+
+class DecoderWrapper(ObjectProxy):
+    def read(self, *args, **kwargs):
+        return self.__wrapped__.read(*args, **kwargs).decode(ENCODING)
+
+    def write(self, data):
+        return self.__wrapped__.write(data.encode(ENCODING))
+
+
+def wrap(x):
+    return DecoderWrapper(x)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 pyserial==3.0.1
 coverage==4.0.3
+wrapt==1.10.10

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,7 +12,7 @@ def get_tests():
 def full_suite():
     """creates a full suite of tests"""
     logging.basicConfig(filename='test.log', level=logging.INFO,
-        ormat='%(asctime)s %(levelname)s %(module)s.%(funcName)s %(message)s')
+        format='%(asctime)s %(levelname)s %(module)s.%(funcName)s %(message)s')
 
     from .misc import MiscTestCase
     from . import uploader

--- a/tests/uploader.py
+++ b/tests/uploader.py
@@ -40,7 +40,6 @@ class UploaderTestCase(unittest.TestCase):
         self.uploader.prepare()
         self.uploader.write_file('tests/fixtures/big_file.txt', verify='raw')
 
-
     def test_upload_and_verify_sha1(self):
         self.uploader.prepare()
         self.uploader.write_file('tests/fixtures/big_file.txt', verify='sha1')

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27, py36
+
+[testenv]
+deps = -rtest_requirements.txt
+commands = python -m unittest -v tests.get_tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,8 @@
 [tox]
-envlist = py27, py36
+envlist = py27, py35
 
 [testenv]
 deps = -rtest_requirements.txt
 commands = python -m unittest -v tests.get_tests
+setenv =
+  SERIALPORT=/dev/ttyACM0


### PR DESCRIPTION
Python 3.6: all tests are passing.
Python 2.7: uploading tests are failing because of encoding error. But googling tells that it's a Windows cmd [problem](http://stackoverflow.com/questions/23370025/what-is-unicode-literals-used-for), not Python. Maybe it will be OK on Linux.

Basically, I've just add a proxy object to serial port, which translates all data to/from bytes. **Latin1** encoding does all _magic_.