### PR TITLE
Add --autobaud_time argument to allow changing the autobaud timer

### DIFF
--- a/nodemcu_uploader/main.py
+++ b/nodemcu_uploader/main.py
@@ -152,6 +152,13 @@ def main_func():
         type=arg_auto_int,
         default=Uploader.TIMEOUT)
 
+    parser.add_argument(
+        '--autobaud_time', '-a',
+        help='Duration of the autobaud timer',
+        type=float,
+        default=Uploader.AUTOBAUD_TIME,
+    )
+
     subparsers = parser.add_subparsers(
         dest='operation',
         help='Run nodemcu-uploader {command} -h for additional help')
@@ -249,7 +256,7 @@ def main_func():
         return
 
     # let uploader user the default (short) timeout for establishing connection
-    uploader = Uploader(args.port, args.baud, start_baud=args.start_baud)
+    uploader = Uploader(args.port, args.baud, start_baud=args.start_baud, autobaud_time=args.autobaud_time)
 
     # and reset the timeout (if we have the uploader&timeout)
     if args.timeout:

--- a/nodemcu_uploader/uploader.py
+++ b/nodemcu_uploader/uploader.py
@@ -39,9 +39,10 @@ class Uploader(object):
     BAUD = 115200
     START_BAUD = 115200
     TIMEOUT = 5
+    AUTOBAUD_TIME = 0.3
     PORT = default_port()
 
-    def __init__(self, port=PORT, baud=BAUD, start_baud=START_BAUD, timeout=TIMEOUT):
+    def __init__(self, port=PORT, baud=BAUD, start_baud=START_BAUD, timeout=TIMEOUT, autobaud_time=AUTOBAUD_TIME):
         self._timeout = Uploader.TIMEOUT
         self.set_timeout(timeout)
         log.info('opening port %s with %s baud', port, start_baud)
@@ -55,6 +56,7 @@ class Uploader(object):
 
         self.start_baud = start_baud
         self.baud = baud
+        self.autobaud_time = autobaud_time
         # Keeps things working, if following conections are made:
         ## RTS = CH_PD (i.e reset)
         ## DTR = GPIO0
@@ -68,7 +70,7 @@ class Uploader(object):
             try:
                 self.__writeln('UUUUUUUUUUUU') # Send enough characters for auto-baud
                 self.__clear_buffers()
-                time.sleep(0.30) # Wait for autobaud timer to expire
+                time.sleep(self.autobaud_time) # Wait for autobaud timer to expire
                 self.__exchange(';') # Get a defined state
                 self.__writeln('print("%sync%");')
                 self.__expect('%sync%\r\n> ')


### PR DESCRIPTION
Proposed change in order to allow specifying the time of the "autobaud timer" on the command line, because the current, hardcoded value of 0.3 seconds is causing problems/is too short for some people. (see #60)