### PR TITLE
Fix for downloading in the current folder

### DIFF
--- a/nodemcu-uploader.py
+++ b/nodemcu-uploader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Copyright (C) 2015-2016 Peter Magnusson <peter@birchroad.net>
 #pylint: disable=C0103

--- a/nodemcu_uploader/uploader.py
+++ b/nodemcu_uploader/uploader.py
@@ -250,7 +250,8 @@ class Uploader(object):
 
         # Just in case, the filename may contain folder, so create it if needed.
         log.info(destination)
-        if not os.path.exists(os.path.dirname(destination)):
+        dirpath1 = os.path.dirname(destination)
+        if len(dirpath1) > 0 and not os.path.exists(dirpath1):
             try:
                 os.makedirs(os.path.dirname(destination))
             except OSError as e:  # Guard against race condition


### PR DESCRIPTION
if I use "**nodemcu-uploader/nodemcu-uploader.py download weather-config.lua**" for example, I'm getting the following error :

> opening port /dev/ttyUSB0 with 115200 baud
> sources ['weather-config.lua']
> destinations ['weather-config.lua']
> Preparing esp for transfer.
> Transferring weather-config.lua to weather-config.lua
> receiveing send("weather-config.lua")
> > weather-config.lua
> weather-config.lua
> Traceback (most recent call last):
>   File "nodemcu-uploader/nodemcu-uploader.py", line 11, in <module>
>     main.main_func()
>   File "/home/jpierre/ESP8266/nodemcu-uploader/nodemcu_uploader/main.py", line 281, in main_func
>     operation_download(uploader, args.filename)
>   File "/home/jpierre/ESP8266/nodemcu-uploader/nodemcu_uploader/main.py", line 83, in operation_download
>     uploader.read_file(filename, dst)
>   File "/home/jpierre/ESP8266/nodemcu-uploader/nodemcu_uploader/uploader.py", line 255, in read_file
>     os.makedirs(os.path.dirname(destination))
>   File "/usr/lib/python3.6/os.py", line 220, in makedirs
>     mkdir(name, mode)
> FileNotFoundError: [Errno 2] No such file or directory: ''

Check that the filename contains a folder before making a new folder ! So, after commit that works fine :

> opening port /dev/ttyUSB0 with 115200 baud
> sources ['weather-config.lua']
> destinations ['weather-config.lua']
> Preparing esp for transfer.
> Preparation already done. Not adding functions again.
> Transferring weather-config.lua to weather-config.lua
> receiveing weather-config.lua
> weather-config.lua
> All done!

Sorry, but I'm working with Python 3.
