### PR TITLE
Support SHA1 verification in new versions of NodeMCU

### DIFF
--- a/nodemcu_uploader/luacode.py
+++ b/nodemcu_uploader/luacode.py
@@ -32,7 +32,12 @@ function recv()
     on('data', '\0', recv_name, 0)
     w(0, 'C')
   end
-function shafile(f) print(crypto.toHex(crypto.fhash('sha1', f))) end
+function shafile(f)
+    if not crypto then print("unsupported") return end
+    local toHex = crypto.toHex and crypto.toHex or
+        (encoder and encoder.toHex or function() return "unsupported" end)
+    print(toHex(crypto.fhash('sha1', f)))
+end
 """  # noqa: E122
 
 SEND_LUA = \

--- a/nodemcu_uploader/uploader.py
+++ b/nodemcu_uploader/uploader.py
@@ -339,14 +339,17 @@ class Uploader(object):
             else:
                 log.info('Verification successful. Contents are identical.')
         elif verify == 'sha1':
-            # Calculate SHA1 on remote file. Extract just hash from result
-            data = self.__exchange('shafile("'+remote+'")').splitlines()[1]
+            # Calculate SHA1 on remote file
+            data = self.__exchange('shafile("'+remote+'")')
             log.info('Remote SHA1: %s', data)
 
             # Calculate hash of local data
             filehashhex = hashlib.sha1(content).hexdigest()
             log.info('Local SHA1: %s', filehashhex)
-            if data != filehashhex:
+            if "unsupported" in data:
+                log.error('SHA1 verification unsupported - crypto and encoder modules not found in firmware.')
+                raise VerificationError('SHA1 verification unsupported - crypto and encoder modules not found in firmware.')
+            elif filehashhex not in data:
                 log.error('SHA1 verification failed.')
                 raise VerificationError('SHA1 Verification failed.')
             else:


### PR DESCRIPTION
As NodeMCU recently moved `toHex` and `toBase64` functions to `encoder` module SHA1 file verification stopped working. This patch fixes that issue and should make SHA1 verification work with both old (with `crypto.toHex` and it's depreciation notice) and new (with `encoder.toHex`) versions of the firmware.