### PR TITLE
setup.cfg: Replace description-file with description_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [metadata]
-description-file=README.md
+description_file=README.md
 licence=LICENSE


### PR DESCRIPTION
- Setuptools triggered a warning:
Usage of dash-separated 'description-file' will not be supported in
future versions. Please use the underscore name 'description_file'
instead