### PR TITLE
Fix upload, print to support IDF v3 and v4 (and Lua 5.3)

### DIFF
--- a/nodemcu_uploader/luacode.py
+++ b/nodemcu_uploader/luacode.py
@@ -7,11 +7,9 @@ to perform whats needed. They will be uploaded if they doesn't exist"""
 # flake8: noqa
 
 
-LUA_FUNCTIONS = ['recv_block', 'recv_name', 'recv', 'shafile', 'send_block', 'send_file', 'send']
+LUA_FUNCTIONS = ['recv', 'shafile', 'send']
 
-DOWNLOAD_FILE = "file.open('{filename}') print(file.seek('end', 0)) file.seek('set', {bytes_read}) uart.write(0, file.read({chunk_size}))file.close()"
-
-PRINT_FILE = "file.open('{filename}') print('---{filename}---') print(file.read()) file.close() print('---')"
+PRINT_FILE = "do local fd,data = (file.open or io.open)('{filename}'), '---{filename}---\\n'; while data do uart.write(0, data) data = fd:read(1024) end fd:close() uart.write(0, '---\\n') end"
 
 INFO_GROUP = "for key,value in pairs(node.info('{group}')) do k=tostring(key) print(k .. string.rep(' ', 20 - #k), tostring(value)) end"
 
@@ -21,6 +19,7 @@ RECV_LUA = \
 r"""
 function recv()
     local on,w,ack,nack=uart.on,uart.write,'\6','\21'
+    local fopen = file.open or io.open
     local fd
     local function recv_block(d)
         local t,l = d:byte(1,2)
@@ -28,7 +27,7 @@ function recv()
         if l >= 0  then fd:write(d:sub(3, l+2)); end
         if l == 0 then fd:close(); w(0, ack); return on('data') else w(0, ack) end
     end
-    local function recv_name(d) d = d:gsub('%z.*', '') d:sub(1,-2) file.remove(d) fd=file.open(d, 'w') on('data', 130, recv_block, 0) w(0, ack) end
+    local function recv_name(d) d = d:gsub('%z.*', '') file.remove(d) fd=fopen(d, 'w') on('data', 130, recv_block, 0) w(0, ack) end
     on('data', '\0', recv_name, 0)
     w(0, 'C')
   end
@@ -37,23 +36,34 @@ function shafile(f) print(crypto.toHex(crypto.fhash('sha1', f))) end
 
 SEND_LUA = \
 r"""
-function send(f) uart.on('data', 1, function (data)
-  local on,w=uart.on,uart.write
-  local fd
-  local function send_block(d) l = string.len(d) w(0, '\001' .. string.char(l) .. d .. string.rep('\0', 128 - l)) return l end
-  local function send_file(f)
-    local s, p
-    fd=file.open(f) s=fd:seek('end', 0) p=0
+function send(f)
+  local fd = (file.open or io.open)(f)
+  if fd == nil then
+    print('un'..'expected could not open '..f)
+    return
+  end
+  local on,w,len,ch,rep=uart.on,uart.write,string.len,string.char,string.rep
+  local function send_block(d)
+    local l = len(d)
+    w(0, '\001' .. ch(l) .. d .. rep('\0', 128 - l))
+    return l
+  end
+  local function send_file()
+    local s, p = fd:seek('end', 0), 0
+    fd:seek('set', 0)
     on('data', 1, function(data)
       if data == '\006' and p<s then
-        fd:seek('set',p) p=p+send_block(fd:read(128))
+        p=p+send_block(fd:read(128))
       else
         send_block('') fd:close() on('data') print('interrupted')
       end
     end, 0)
     w(0, f .. '\000')
   end
-  uart.on('data') if data == 'C' then send_file(f) else print('transfer interrupted') end end, 0)
+  on('data', 1, function(data)
+    uart.on('data')
+    if data == 'C' then send_file() else print('transfer interrupted') fd:close() end
+  end, 0)
 end
 """
 

--- a/nodemcu_uploader/uploader.py
+++ b/nodemcu_uploader/uploader.py
@@ -238,7 +238,7 @@ class Uploader(object):
         self.__write('C')
         # we should get a NUL terminated filename to start with
         sent_filename = self.__expect(NUL).strip()
-        log.info('receiveing ' + sent_filename)
+        log.info('receiving ' + sent_filename)
 
         # ACK to start download
         self.__write(ACK, True)


### PR DESCRIPTION
Specifically:
* Handle file.open (IDF v3) vs io.open (v4)
* Removed DOWNLOAD_FILE (wasn't used anywhere)
* Removed incorrect inclusions in LUA_FUNCTIONS which guaranteed that function reuse would never occur.
* Replaced file.read() (old API, no longer supported in IDF v4) with fd:read()
* Removed unnecessary d:sub(1,-2) which had no effect, in recv_name
* Fix typo in download_file
* Support 'print' command for files larger than 1024 bytes - this meant switching from using print() to uart.write()
* Better error handling in 'download' if the file doesn't exist

Note, the 'download' command seems to be broken on esp32 even with Lua 5.1 and IDF v3 because of line ending conversion, and I haven't fixed that here.

Tested on esp8266 (with some old Lua 5.1 ROM on it), esp32 with IDF v3 and Lua 5.1 (from dev-esp32 branch); and esp32 with v4 and Lua 5.3 (from dev-esp32-idf4 branch). IDF v4 with Lua 5.1 should work fine too. 'download' command only tested successfully on esp8266.